### PR TITLE
Test and docs updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,14 @@ python:
   - 3.3
   - 3.4
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
+  - pip install -r requirements.txt
   - pip install -r test-requirements.txt
-  - pip install -e .
 script: nosetests
 after_success:
   - coveralls
+addons:
+  postgresql: "9.3"
 deploy:
   provider: pypi
   user: sprockets

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,2 @@
 include LICENSE
 include README.rst
-include *requirements.txt
-graft docs
-graft tests.py
-global-exclude __pycache__
-global-exclude *.pyc

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,6 @@ https://sprocketsclientspostgresql.readthedocs.org
 Requirements
 ------------
 -  `queries`_
--  `sprockets <https://github.com/sprockets/sprockets>`_
 
 Example
 -------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,3 @@
--r requirements.txt
--r test-requirements.txt
-flake8>=2.1,<3
 sphinx>=1.2,<2
 sphinx-rtd-theme>=0.1,<1.0
 sphinxcontrib-httpdomain>=1.2,<2

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,12 @@
 .. automodule:: sprockets.clients.postgresql
-   :members:
-   :inherited-members:
+
+Session Classes
+---------------
+
+.. autoclass:: sprockets.clients.postgresql.Session
+    :members:
+    :inherited-members:
+
+.. autoclass:: sprockets.clients.postgresql.TornadoSession
+    :members:
+    :inherited-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,9 +23,8 @@ pygments_style = 'sphinx'
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
+    'python': ('https://docs.python.org/2/', None),
     'queries': ('https://queries.readthedocs.org/en/latest/', None),
-    'requests': ('https://requests.readthedocs.org/en/latest/', None),
     'sprockets': ('https://sprockets.readthedocs.org/en/latest/', None),
     'tornado': ('http://www.tornadoweb.org/en/stable/', None),
 }

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -17,3 +17,31 @@ PostgreSQL on localhost to the ``postgres`` database and issues a query.
     session = postgresql.Session('postgres')
     result = session.query('SELECT 1')
     print(repr(result))
+
+
+The following example shows how to use the :py:class:`TornadoSession <sprockets.clients.postgresql.TornadoSession>`
+class in a Tornado :py:class:`RequestHandler <tornado.web.RequestHandler>`.
+
+.. code:: python
+
+    import os
+
+    from tornado import gen
+    from sprockets.clients import postgresql
+    from tornado import web
+
+    os.environ['POSTGRES_HOST'] = 'localhost'
+    os.environ['POSTGRES_USER'] = 'postgres'
+    os.environ['POSTGRES_PORT'] = 5432
+    os.environ['POSTGRES_DBNAME'] = 'postgres'
+
+    class RequestHandler(web.RequestHandler):
+
+        def initialize(self):
+            self.session = postgresql.TornadoSession('postgres')
+
+        @gen.coroutine
+        def get(self, *args, **kwargs):
+            result = yield self.session.query('SELECT 1')
+            self.write(result.as_dict())
+            result.free()

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,4 +1,7 @@
 Version History
 ---------------
+- 1.0.1 [2014-09-03]
+ - Expose psycopg2/queries exceptions, objects, etc from ``sprockets.queries.postgresql``
+ - Add integration testing with PostgreSQL
 - 1.0.0 [2014-08-29]
  - Initial release

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-queries>=1.2.1
-sprockets>=0.1.1
+queries>=1.4.0
 tornado>=4.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,3 @@ build-dir = build/docs
 with-coverage = 1
 cover-package = sprockets.clients.postgresql
 verbose = 1
-
-[flake8]
-exclude = build,dist,docs,env

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,6 @@
 import codecs
-import sys
 
 import setuptools
-
-
-def read_requirements_file(req_name):
-    requirements = []
-    try:
-        with codecs.open(req_name, encoding='utf-8') as req_file:
-            for req_line in req_file:
-                if '#' in req_line:
-                    req_line = req_line[0:req_line.find('#')].strip()
-                if req_line:
-                    requirements.append(req_line.strip())
-    except IOError:
-        pass
-    return requirements
-
-
-install_requires = read_requirements_file('requirements.txt')
-setup_requires = read_requirements_file('setup-requirements.txt')
-tests_require = read_requirements_file('test-requirements.txt')
-
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
-if sys.version_info < (3, 0):
-    tests_require.append('mock')
 
 setuptools.setup(
     name='sprockets.clients.postgresql',
@@ -60,10 +35,6 @@ setuptools.setup(
               'sprockets.clients.postgresql'],
     package_data={'': ['LICENSE', 'README.rst']},
     include_package_data=True,
-    namespace_packages=['sprockets',
-                        'sprockets.clients'],
-    install_requires=install_requires,
-    setup_requires=setup_requires,
-    tests_require=tests_require,
-    test_suite='nose.collector',
+    namespace_packages=['sprockets', 'sprockets.clients'],
+    install_requires=['queries'],
     zip_safe=False)

--- a/sprockets/clients/postgresql/__init__.py
+++ b/sprockets/clients/postgresql/__init__.py
@@ -1,6 +1,6 @@
 """
-PostgreSQL Session Classes
-==========================
+PostgreSQL Session API
+======================
 The Session classes wrap the Queries :py:class:`Session <queries.Session>` and
 :py:class:`TornadoSession <queries.tornado_session.TornadoSession>` classes
 providing environment variable based configuration.
@@ -30,7 +30,7 @@ The uri ``postgresql://bar:baz@foodb:6000/foo`` will be used when creating the
 instance of :py:class:`queries.Session`.
 
 """
-version_info = (1, 0, 0)
+version_info = (1, 0, 1)
 __version__ = '.'.join(str(v) for v in version_info)
 
 import logging
@@ -43,6 +43,26 @@ from queries import tornado_session
 _ARGUMENTS = ['host', 'port', 'dbname', 'user', 'password']
 
 LOGGER = logging.getLogger(__name__)
+
+
+# For ease of access to different cursor types
+from queries import DictCursor
+from queries import NamedTupleCursor
+from queries import RealDictCursor
+from queries import LoggingCursor
+from queries import MinTimeLoggingCursor
+
+# Expose exceptions so clients do not need to import queries as well
+from queries import DataError
+from queries import DatabaseError
+from queries import IntegrityError
+from queries import InterfaceError
+from queries import InternalError
+from queries import NotSupportedError
+from queries import OperationalError
+from queries import ProgrammingError
+from queries import QueryCanceledError
+from queries import TransactionRollbackError
 
 
 def _get_uri(dbname):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 coverage>=3.7,<4
 coveralls>=0.4,<1
 nose>=1.3,<2
+mock==1.0.1


### PR DESCRIPTION
- Bumps the min version of queries to 1.3.0 to address a PYPY async issue
- Adds integration testing
- Imports exceptions and cursors and such from queries into sprockets.clients.postgresql
- Updates documentation
- Ensures that unittest2 is installed for Python 2.6 on travis
