### PR TITLE
Create sessions from URL

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,6 @@
+-r requirements.txt
+-r test-requirements.txt
+detox>=0.9,<1
 sphinx>=1.2,<2
 sphinx-rtd-theme>=0.1,<1.0
 sphinxcontrib-httpdomain>=1.2,<2

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,5 +1,7 @@
 Version History
 ---------------
+- 2.0.1 [2014-11-14]
+ - Add db_url parameter to both session class initializers.
 - 2.0.0 [2014-10-07]
  - Change the environment variable format to be URI based instead of a variable per host, port, dbname, etc.
 - 1.0.1 [2014-09-05]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name='sprockets.clients.postgresql',
-    version='2.0.0',
+    version='2.0.1',
     description=('PostgreSQL client library wrapper providing environment '
                  'variable based configuration'),
     long_description=codecs.open('README.rst', encoding='utf-8').read(),

--- a/sprockets/clients/postgresql/__init__.py
+++ b/sprockets/clients/postgresql/__init__.py
@@ -95,13 +95,18 @@ class Session(queries.Session):
     :param queries.cursor: The cursor type to use
     :param int pool_idle_ttl: How long idle pools keep connections open
     :param int pool_max_size: The maximum size of the pool to use
+    :param str db_url: Optional database connection URL.  Use this when
+        you need to connect to a database that is only known at runtime.
 
     """
     def __init__(self, dbname,
                  cursor_factory=queries.RealDictCursor,
                  pool_idle_ttl=pool.DEFAULT_IDLE_TTL,
-                 pool_max_size=pool.DEFAULT_MAX_SIZE):
-        super(Session, self).__init__(_get_uri(dbname),
+                 pool_max_size=pool.DEFAULT_MAX_SIZE,
+                 db_url=None):
+        if db_url is None:
+            db_url = _get_uri(dbname)
+        super(Session, self).__init__(db_url,
                                       cursor_factory,
                                       pool_idle_ttl,
                                       pool_max_size)
@@ -125,14 +130,18 @@ class TornadoSession(tornado_session.TornadoSession):
     :param int pool_max_size: The maximum size of the pool to use
     :param tornado.ioloop.IOLoop ioloop: Pass in the instance of the tornado
         IOLoop you would like to use. Defaults to the global instance.
+    :param str db_url: Optional database connection URL.  Use this when
+        you need to connect to a database that is only known at runtime.
 
     """
     def __init__(self, dbname,
                  cursor_factory=queries.RealDictCursor,
                  pool_idle_ttl=pool.DEFAULT_IDLE_TTL,
                  pool_max_size=tornado_session.DEFAULT_MAX_POOL_SIZE,
-                 io_loop=None):
-        super(TornadoSession, self).__init__(_get_uri(dbname),
+                 io_loop=None, db_url=None):
+        if db_url is None:
+            db_url = _get_uri(dbname)
+        super(TornadoSession, self).__init__(db_url,
                                              cursor_factory,
                                              pool_idle_ttl,
                                              pool_max_size,

--- a/sprockets/clients/postgresql/__init__.py
+++ b/sprockets/clients/postgresql/__init__.py
@@ -30,7 +30,7 @@ running on ``foohost``, port ``6000`` using the username ``bar`` and the
 password ``baz``, connecting to the ``foo`` database.
 
 """
-version_info = (2, 0, 0)
+version_info = (2, 0, 1)
 __version__ = '.'.join(str(v) for v in version_info)
 
 import logging

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py26,py27,py33,py34
+
+[testenv]
+deps =
+	-rrequirements.txt
+	-rtest-requirements.txt
+commands = {envbindir}/nosetests
+
+[testenv:py26]
+deps =
+	{[testenv]deps}
+	unittest2


### PR DESCRIPTION
When you need to connect to a database that is only known at runtime, the existing API required that you define a new database name and store the URL in the appropriate environment variable.  This PR adds a `db_url` keyword parameter to the session classes that provides a URL directly.  The `dbname` parameter is still required to maintain compatibility.  If it is truly unnecessary, then we can remove it in a future release.
